### PR TITLE
Inverted MUTE values for Faust

### DIFF
--- a/src/lrnetserver/lrnet_roster.cpp
+++ b/src/lrnetserver/lrnet_roster.cpp
@@ -105,7 +105,7 @@ Member * Roster::addMemberOrChef(QString &netid,
         return NULL;
     }
     Member * newMem = new Member(netid, s_id, this);
-    newMem->setControl(Member::MUTE, (float)mJoinMuted);
+    newMem->setControl(Member::MUTE, (float)!mJoinMuted); // Inverted because client muted when MUTE == 0
     group[s_id]=newMem;
     sGroup[newMem->getSerialID()]=newMem;    
     return newMem;

--- a/src/rehearsalchef/channelstrip.cpp
+++ b/src/rehearsalchef/channelstrip.cpp
@@ -69,7 +69,7 @@ void ChannelStrip::setSection(const QString & nsection){
 }
 
 void ChannelStrip::sendMute(bool checked){
-    emit valueChanged(mCStruct, (int)MUTE, (float)checked);
+    emit valueChanged(mCStruct, (int)MUTE, (float)!checked); // Inverted because Faust considers 0 muted
 
     //Commented out until behavior of solo is known
 //    if (checked && ui->cs_soloButton->isChecked()){
@@ -111,5 +111,5 @@ void ChannelStrip::setSolo(bool checked){
 void ChannelStrip::newControls(QVector<float> & controls){
     currentControls = controls;
     setPostGainWithoutSignal(controls[7]);
-    setMutedWithoutSignal(controls[8]);
+    setMutedWithoutSignal(!controls[8]); // Inverted because Fause considers 0 muted
 }

--- a/src/rehearsalchef/chefform.cpp
+++ b/src/rehearsalchef/chefform.cpp
@@ -20,7 +20,7 @@ ChefForm::ChefForm(QWidget *parent) :
     QObject::connect(ui->authCodeEdit, &QLineEdit::editingFinished, this, &ChefForm::updateAuthCode);
     QObject::connect(ui->codeEnabledBox, &QCheckBox::stateChanged, this, &ChefForm::updateAuthCodeEnabled);
     QObject::connect(ui->tbSetupButton, &QAbstractButton::released, m_tbSetupForm, &QWidget::show);
-    QObject::connect(ui->joinMutedBox, &QAbstractButton::toggled, this, &ChefForm::sendJoinMutedUpdate);
+    QObject::connect(ui->joinMutedBox, &QAbstractButton::toggled, this, &ChefForm::sigJoinMutedUpdate);
     QObject::connect(m_tbSetupForm, &TalkbackSettingsForm::startJackTrip, this, [=](){emit startJackTrip();});
     QObject::connect(m_tbSetupForm, &TalkbackSettingsForm::stopJackTrip, this, [=](){emit stopJackTrip();});
     QObject::connect(m_tbSetupForm, &TalkbackSettingsForm::setjtSelfLoopback, this, &ChefForm::setjtSelfLoopback);
@@ -185,8 +185,14 @@ void ChefForm::handleSoloResponse(int id, bool isSolo){
         m_clients[id]->cs->setSolo(isSolo);
 }
 
+void ChefForm::sigJoinMutedUpdate(){
+    emit sendJoinMutedUpdate(ui->joinMutedBox->isChecked());
+}
+
 void ChefForm::handleJoinMutedResponse(bool joinMuted){
+    QObject::disconnect(ui->joinMutedBox, &QAbstractButton::toggled, this, &ChefForm::sigJoinMutedUpdate);
     ui->joinMutedBox->setChecked(joinMuted);
+    QObject::connect(ui->joinMutedBox, &QAbstractButton::toggled, this, &ChefForm::sigJoinMutedUpdate);
     qDebug() << "set muted box checked to " << joinMuted;
 }
 

--- a/src/rehearsalchef/chefform.h
+++ b/src/rehearsalchef/chefform.h
@@ -45,6 +45,7 @@ public slots:
     void soloRequested(int id, bool checked);
     void muteAll(bool mute);
     void handleSoloResponse(int id, bool isSolo);
+    void sigJoinMutedUpdate();
     void handleJoinMutedResponse(bool joinMuted);
     void addChannelStrip(const QString& mName, const QString& sName, QVector<float> controls, int id);
     void updateChannelStrip(const QString& mName, const QString& sName, int id);


### PR DESCRIPTION
Turns out 0 means mute and 1 means unmuted, so I had to invert some values pertaining to the join muted functionality and the channel strip's mute behavior.